### PR TITLE
Updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,6 @@ matrix:
     - php: 7
     - php: hhvm 
   allow_failures:
-    - php: 7
     - php: hhvm
 
 notifications:

--- a/composer.json
+++ b/composer.json
@@ -13,17 +13,17 @@
         }
     },
     "require": {
-        "php": ">=5.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "php": "^5.5 || ^7.0",
+        "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "zendframework/zend-db": "~2.5",
-        "zendframework/zend-crypt": "~2.5",
-        "zendframework/zend-http": "~2.5",
-        "zendframework/zend-ldap": "~2.5",
-        "zendframework/zend-session": "~2.5",
-        "zendframework/zend-validator": "~2.5",
-        "zendframework/zend-uri": "~2.5",
+        "zendframework/zend-db": "^2.7",
+        "zendframework/zend-crypt": "^2.6",
+        "zendframework/zend-http": "^2.5.4",
+        "zendframework/zend-ldap": "^2.6",
+        "zendframework/zend-session": "^2.6.2",
+        "zendframework/zend-validator": "^2.6",
+        "zendframework/zend-uri": "^2.5",
         "fabpot/php-cs-fixer": "1.7.*",
         "phpunit/PHPUnit": "~4.0"
     },


### PR DESCRIPTION
- Allow use with zend-stdlib 3.0 (and components that are forwards-compatible with it). This is being done to provide forwards-compatibility and to allow testing zend-mvc against v3 components.
- Require PHP 7 builds to pass.
