### PR TITLE
Fixing Deprecated Class Name In Docs

### DIFF
--- a/doc/book/adapter/dbtable/callback-check.md
+++ b/doc/book/adapter/dbtable/callback-check.md
@@ -3,7 +3,7 @@
 Some verification operations cannot be performed well on RDBMS servers. Other
 times, you may be unsure which RDBMS system you will be using long-term, and
 need to ensure authentication will work consistently. For these situations, you
-can use the `Zend\Authentication\Adapter\DbTable\CallbackCheck` adapter.
+can use the `Zend\Authentication\Adapter\DbTable\CallbackCheckAdapter` adapter.
 Similar to the [CredentialTreatmentAdapter](credential-treatment.md), it
 accepts a table name, identity column, and credential column; however, instead
 of a credential treatment, it accepts a *credential validation callback* that
@@ -92,11 +92,11 @@ $passwordValidation = function ($hash, $password) {
 ```
 
 Now that we have the database connection and a password validation function,
-we can create our `Zend\Authentication\Adapter\DbTable\CallbackCheck` adapter
+we can create our `Zend\Authentication\Adapter\DbTable\CallbackCheckAdapter` adapter
 instance, passing the options to the constructor or later via setter methods:
 
 ```php
-use Zend\Authentication\Adapter\DbTable\CallbackCheck as AuthAdapter;
+use Zend\Authentication\Adapter\DbTable\CallbackCheckAdapter as AuthAdapter;
 
 // Configure the instance with constructor parameters:
 $authAdapter = new AuthAdapter(
@@ -133,7 +133,7 @@ $result = $authAdapter->authenticate();
 ```
 
 In addition to the availability of the `getIdentity()` method upon the
-authentication result object, `Zend\Authentication\Adapter\DbTable\CallbackCheck`
+authentication result object, `Zend\Authentication\Adapter\DbTable\CallbackCheckAdapter`
 also supports retrieving the table row upon authentication success:
 
 ```php


### PR DESCRIPTION
Fixing Deprecated Class Name In Docs:

Zend\Authentication\Adapter\DbTable\CallbackCheck to Zend\Authentication\Adapter\DbTable\CallbackCheckAdapter
