### PR TITLE
Update Authentication validator

### DIFF
--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -72,7 +72,7 @@ class Authentication extends AbstractValidator
      * Authentication\Result codes mapping
      * @var array
      */
-    static protected $codeMap = [
+    protected static $codeMap = [
         Result::FAILURE_IDENTITY_NOT_FOUND => self::IDENTITY_NOT_FOUND,
         Result::FAILURE_CREDENTIAL_INVALID => self::CREDENTIAL_INVALID,
         Result::FAILURE_IDENTITY_AMBIGUOUS => self::IDENTITY_AMBIGUOUS,

--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -69,6 +69,17 @@ class Authentication extends AbstractValidator
     protected $service;
 
     /**
+     * Authentication\Result codes mapping
+     * @var array
+     */
+    static protected $codeMap = [
+        Result::FAILURE_IDENTITY_NOT_FOUND => self::IDENTITY_NOT_FOUND,
+        Result::FAILURE_CREDENTIAL_INVALID => self::CREDENTIAL_INVALID,
+        Result::FAILURE_IDENTITY_AMBIGUOUS => self::IDENTITY_AMBIGUOUS,
+        Result::FAILURE_UNCATEGORIZED      => self::UNCATEGORIZED,
+    ];
+
+    /**
      * Sets validator options
      *
      * @param mixed $options
@@ -189,11 +200,16 @@ class Authentication extends AbstractValidator
     }
 
     /**
-     * Is Valid
+     * Returns true if and only if authentication result is valid
      *
-     * @param  mixed $value
-     * @param  array $context
+     * If authentication result fails validation, then this method returns false, and
+     * getMessages() will return an array of messages that explain why the
+     * validation failed.
+     *
+     * @param  mixed $value   OPTIONAL Credential (or field)
+     * @param  array $context OPTIONAL Authentication data (identity and/or credential)
      * @return bool
+     * @throws Exception\RuntimeException
      */
     public function isValid($value = null, $context = null)
     {
@@ -201,49 +217,54 @@ class Authentication extends AbstractValidator
             $this->setCredential($value);
         }
 
+        if ($this->identity === null) {
+            throw new Exception\RuntimeException('Identity must be set prior to validation');
+        }
         if (($context !== null) && array_key_exists($this->identity, $context)) {
             $identity = $context[$this->identity];
         } else {
             $identity = $this->identity;
         }
-        if (!$this->identity) {
-            throw new Exception\RuntimeException('Identity must be set prior to validation');
-        }
 
+        if ($this->credential === null) {
+            throw new Exception\RuntimeException('Credential must be set prior to validation');
+        }
         if (($context !== null) && array_key_exists($this->credential, $context)) {
             $credential = $context[$this->credential];
         } else {
             $credential = $this->credential;
         }
 
-        if (!$this->adapter) {
-            throw new Exception\RuntimeException('Adapter must be set prior to validation');
-        }
-        $this->adapter->setIdentity($identity);
-        $this->adapter->setCredential($credential);
-
         if (!$this->service) {
             throw new Exception\RuntimeException('AuthenticationService must be set prior to validation');
         }
+
+        if (!$this->adapter) {
+            $adapter = $this->service->getAdapter();
+            if (!$adapter) {
+                throw new Exception\RuntimeException('Adapter must be set prior to validation');
+            }
+            if (!$adapter instanceof ValidatableAdapterInterface) {
+                throw new Exception\RuntimeException(sprintf(
+                    'Adapter must be an instance of ValidatableAdapterInterface, %s given',
+                    (is_object($adapter) ? get_class($adapter) : gettype($adapter))
+                ));
+            }
+        } else {
+            $adapter = $this->adapter;
+        }
+
+        $adapter->setIdentity($identity);
+        $adapter->setCredential($credential);
+
         $result = $this->service->authenticate($this->adapter);
 
-        if ($result->getCode() != Result::SUCCESS) {
-            switch ($result->getCode()) {
-                case Result::FAILURE_IDENTITY_NOT_FOUND:
-                    $this->error(self::IDENTITY_NOT_FOUND);
-                    break;
-                case Result::FAILURE_CREDENTIAL_INVALID:
-                    $this->error(self::CREDENTIAL_INVALID);
-                    break;
-                case Result::FAILURE_IDENTITY_AMBIGUOUS:
-                    $this->error(self::IDENTITY_AMBIGUOUS);
-                    break;
-                case Result::FAILURE_UNCATEGORIZED:
-                    $this->error(self::UNCATEGORIZED);
-                    break;
-                default:
-                    $this->error(self::GENERAL);
+        if (!$result->isValid()) {
+            $code = self::GENERAL;
+            if (array_key_exists($result->getCode(), static::$codeMap)) {
+                $code = static::$codeMap[$result->getCode()];
             }
+            $this->error($code);
 
             return false;
         }

--- a/test/AuthenticationServiceTest.php
+++ b/test/AuthenticationServiceTest.php
@@ -35,7 +35,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
     public function testAdapter()
     {
         $this->assertNull($this->auth->getAdapter());
-        $successAdapter = new TestAsset\SuccessAdapter();
+        $successAdapter = new TestAsset\ValidatableAdapter();
         $ret = $this->auth->setAdapter($successAdapter);
         $this->assertSame($ret, $this->auth);
         $this->assertSame($successAdapter, $this->auth->getAdapter());
@@ -56,7 +56,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
 
     public function testAuthenticateSetAdapter()
     {
-        $result = $this->authenticate(new TestAsset\SuccessAdapter());
+        $result = $this->authenticate(new TestAsset\ValidatableAdapter());
         $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
@@ -78,7 +78,7 @@ class AuthenticationServiceTest extends \PHPUnit_Framework_TestCase
     protected function authenticate($adapter = null)
     {
         if ($adapter === null) {
-            $adapter = new TestAsset\SuccessAdapter();
+            $adapter = new TestAsset\ValidatableAdapter();
         }
         return $this->auth->authenticate($adapter);
     }

--- a/test/TestAsset/ValidatableAdapter.php
+++ b/test/TestAsset/ValidatableAdapter.php
@@ -9,13 +9,26 @@
 
 namespace ZendTest\Authentication\TestAsset;
 
-use Zend\Authentication\Adapter\AdapterInterface;
+use Zend\Authentication\Adapter\AbstractAdapter as AuthenticationAdapter;
 use Zend\Authentication\Result as AuthenticationResult;
 
-class SuccessAdapter implements AdapterInterface
+class ValidatableAdapter extends AuthenticationAdapter
 {
+    /**
+     * @var int Authentication result code
+     */
+    protected $code;
+
+    /**
+     * @param int $code
+     */
+    public function __construct($code = AuthenticationResult::SUCCESS)
+    {
+        $this->code = $code;
+    }
+
     public function authenticate()
     {
-        return new AuthenticationResult(AuthenticationResult::SUCCESS, 'someIdentity');
+        return new AuthenticationResult($this->code, 'someIdentity');
     }
 }

--- a/test/Validator/AuthenticationTest.php
+++ b/test/Validator/AuthenticationTest.php
@@ -9,8 +9,10 @@
 
 namespace ZendTest\Authentication\Validator;
 
+use Zend\Authentication\Adapter\ValidatableAdapterInterface;
 use Zend\Authentication\Validator\Authentication as AuthenticationValidator;
 use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\Result as AuthenticationResult;
 use ZendTest\Authentication as AuthTest;
 
 /**
@@ -18,13 +20,26 @@ use ZendTest\Authentication as AuthTest;
  */
 class AuthenticationTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var AuthenticationValidator
+     */
     protected $validator;
+
+    /**
+     * @var AuthenticationService
+     */
+    protected $authService;
+
+    /**
+     * @var ValidatableAdapterInterface
+     */
+    protected $authAdapter;
 
     public function setUp()
     {
         $this->validator = new AuthenticationValidator();
         $this->authService = new AuthenticationService();
-        $this->authAdapter = new AuthTest\TestAsset\SuccessAdapter();
+        $this->authAdapter = new AuthTest\TestAsset\ValidatableAdapter();
     }
 
     public function testOptions()
@@ -62,6 +77,7 @@ class AuthenticationTest extends \PHPUnit_Framework_TestCase
     public function testNoAdapterThrowsRuntimeException()
     {
         $this->setExpectedException('RuntimeException', 'Adapter must be set prior to validation');
+        $this->validator->setService($this->authService);
         $this->validator->setIdentity('username');
         $this->validator->isValid('password');
     }
@@ -105,5 +121,98 @@ class AuthenticationTest extends \PHPUnit_Framework_TestCase
         $adapter = $this->validator->getAdapter();
         $this->assertEquals('myusername', $adapter->getIdentity());
         $this->assertEquals('mypassword', $adapter->getCredential());
+    }
+
+    /**
+     * @param int   $code
+     * @param bool  $valid
+     * @param array $messages
+     *
+     * @dataProvider errorMessagesProvider
+     */
+    public function testErrorMessages($code, $valid, $messages)
+    {
+        $adapter = new AuthTest\TestAsset\ValidatableAdapter($code);
+
+        $this->validator->setAdapter($adapter);
+        $this->validator->setService($this->authService);
+        $this->validator->setIdentity('username');
+        $this->validator->setCredential('credential');
+
+        $this->assertEquals($valid, $this->validator->isValid());
+        $this->assertEquals($messages, $this->validator->getMessages());
+    }
+
+    /**
+     * Test using Authentication Service's adapter
+     */
+    public function testUsingAdapterFromService()
+    {
+        $this->authService->setAdapter($this->authAdapter);
+
+        $this->validator->setService($this->authService);
+        $this->validator->setIdentity('username');
+        $this->validator->isValid('password');
+
+        $this->assertEquals('username', $this->validator->getIdentity());
+        $this->assertEquals('password', $this->validator->getCredential());
+        $this->assertEquals('username', $this->authAdapter->getIdentity());
+        $this->assertEquals('password', $this->authAdapter->getCredential());
+        $this->assertNull($this->validator->getAdapter());
+        $this->assertTrue($this->validator->isValid());
+    }
+
+    /**
+     * Ensures that isValid() throws an exception when Authentication Service's
+     * adapter is not an instance of ValidatableAdapterInterface
+     */
+    public function testUsingNoValiatableAdapterFromServiceThrowsRuntimeException()
+    {
+        $this->setExpectedException(
+            'RuntimeException',
+            'Adapter must be an instance of ValidatableAdapterInterface, ' .
+            'ZendTest\Authentication\TestAsset\SuccessAdapter given'
+        );
+
+        $adapter = new AuthTest\TestAsset\SuccessAdapter();
+        $this->authService->setAdapter($adapter);
+
+        $this->validator->setService($this->authService);
+        $this->validator->setIdentity('username');
+        $this->validator->isValid('password');
+    }
+
+    public function errorMessagesProvider()
+    {
+        return [
+            [
+                AuthenticationResult::FAILURE,
+                false,
+                [AuthenticationValidator::GENERAL => 'Authentication failed'],
+            ],
+            [
+                AuthenticationResult::FAILURE_IDENTITY_NOT_FOUND,
+                false,
+                [AuthenticationValidator::IDENTITY_NOT_FOUND => 'Invalid identity'],
+            ],
+            [
+                AuthenticationResult::FAILURE_IDENTITY_AMBIGUOUS,
+                false,
+                [AuthenticationValidator::IDENTITY_AMBIGUOUS => 'Identity is ambiguous'],
+            ],
+            [
+                AuthenticationResult::FAILURE_CREDENTIAL_INVALID,
+                false,
+                [AuthenticationValidator::CREDENTIAL_INVALID => 'Invalid password'],
+            ],
+            [
+                AuthenticationResult::FAILURE_UNCATEGORIZED,
+                false,
+                [AuthenticationValidator::UNCATEGORIZED => 'Authentication failed'],
+            ],
+            [
+                AuthenticationResult::SUCCESS, true, [],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Authentication validator is able to use adapter from the given AuthenticationService:

``` php
use My\Authentication\Adapter;
use My\Authentication\Storage;
use Zend\Authentication\AuthenticationService;
use Zend\Authentication\Validator\Authentication as AuthenticationValidator;

$adapter = new Adapter();
$storage = new Storage();
$service = new AuthenticationService($storage, $adapter);

$validator = new AuthenticationValidator([
    'service' => $service,
]);

$validator->setIdentity('username');
$validator->isValid('password');
```
