### PR TITLE
Complete #14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#14](https://github.com/zendframework/zend-authentication/pull/14) modifies the `Zend\Authentication\Validator\Authentication` class such that
+  it now will pull an adapter from the composed `AuthenticationService` instance if no
+  authentication adapter is registered directly with the validator. This will only work
+  if the adapter is a `ValidatableAdapterInterface` implementation (all `AbstractAdapter`
+  instances are already implementations).
 
 ### Deprecated
 

--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -72,7 +72,7 @@ class Authentication extends AbstractValidator
      * Authentication\Result codes mapping
      * @var array
      */
-    static protected $codeMap = [
+    protected static $codeMap = [
         Result::FAILURE_IDENTITY_NOT_FOUND => self::IDENTITY_NOT_FOUND,
         Result::FAILURE_CREDENTIAL_INVALID => self::CREDENTIAL_INVALID,
         Result::FAILURE_IDENTITY_AMBIGUOUS => self::IDENTITY_AMBIGUOUS,

--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -33,8 +33,19 @@ class Authentication extends AbstractValidator
     const GENERAL            = 'general';
 
     /**
+     * Authentication\Result codes mapping
+     * @const array
+     */
+    const CODE_MAP = [
+        Result::FAILURE_IDENTITY_NOT_FOUND => self::IDENTITY_NOT_FOUND,
+        Result::FAILURE_CREDENTIAL_INVALID => self::CREDENTIAL_INVALID,
+        Result::FAILURE_IDENTITY_AMBIGUOUS => self::IDENTITY_AMBIGUOUS,
+        Result::FAILURE_UNCATEGORIZED      => self::UNCATEGORIZED,
+    ];
+
+    /**
      * Error Messages
-     * @var array
+     * @const array
      */
     protected $messageTemplates = [
         self::IDENTITY_NOT_FOUND => 'Invalid identity',
@@ -67,17 +78,6 @@ class Authentication extends AbstractValidator
      * @var AuthenticationService
      */
     protected $service;
-
-    /**
-     * Authentication\Result codes mapping
-     * @var array
-     */
-    protected static $codeMap = [
-        Result::FAILURE_IDENTITY_NOT_FOUND => self::IDENTITY_NOT_FOUND,
-        Result::FAILURE_CREDENTIAL_INVALID => self::CREDENTIAL_INVALID,
-        Result::FAILURE_IDENTITY_AMBIGUOUS => self::IDENTITY_AMBIGUOUS,
-        Result::FAILURE_UNCATEGORIZED      => self::UNCATEGORIZED,
-    ];
 
     /**
      * Sets validator options
@@ -248,8 +248,8 @@ class Authentication extends AbstractValidator
         }
 
         $code = self::GENERAL;
-        if (array_key_exists($result->getCode(), static::$codeMap)) {
-            $code = static::$codeMap[$result->getCode()];
+        if (array_key_exists($result->getCode(), self::CODE_MAP)) {
+            $code = self::CODE_MAP[$result->getCode()];
         }
         $this->error($code);
 

--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link       http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright  Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license    http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-authentication for the canonical source repository
+ * @copyright Copyright (c) 2013-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-authentication/blob/master/LICENSE.md New BSD License
  */
 
 namespace Zend\Authentication\Validator;

--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -45,7 +45,7 @@ class Authentication extends AbstractValidator
 
     /**
      * Error Messages
-     * @const array
+     * @var array
      */
     protected $messageTemplates = [
         self::IDENTITY_NOT_FOUND => 'Invalid identity',
@@ -82,7 +82,7 @@ class Authentication extends AbstractValidator
     /**
      * Sets validator options
      *
-     * @param mixed $options
+     * @param array|Traversable $options
      */
     public function __construct($options = null)
     {
@@ -120,7 +120,7 @@ class Authentication extends AbstractValidator
     /**
      * Set Adapter
      *
-     * @param  ValidatableAdapterInterface $adapter
+     * @param ValidatableAdapterInterface $adapter
      * @return Authentication
      */
     public function setAdapter(ValidatableAdapterInterface $adapter)
@@ -143,13 +143,12 @@ class Authentication extends AbstractValidator
     /**
      * Set Identity
      *
-     * @param  mixed          $identity
+     * @param mixed $identity
      * @return Authentication
      */
     public function setIdentity($identity)
     {
         $this->identity = $identity;
-
         return $this;
     }
 
@@ -166,7 +165,7 @@ class Authentication extends AbstractValidator
     /**
      * Set Credential
      *
-     * @param  mixed          $credential
+     * @param mixed $credential
      * @return Authentication
      */
     public function setCredential($credential)
@@ -189,7 +188,7 @@ class Authentication extends AbstractValidator
     /**
      * Set Service
      *
-     * @param  AuthenticationService $service
+     * @param AuthenticationService $service
      * @return Authentication
      */
     public function setService(AuthenticationService $service)
@@ -206,8 +205,8 @@ class Authentication extends AbstractValidator
      * getMessages() will return an array of messages that explain why the
      * validation failed.
      *
-     * @param  mixed $value   OPTIONAL Credential (or field)
-     * @param  array $context OPTIONAL Authentication data (identity and/or credential)
+     * @param null|mixed $value OPTIONAL Credential (or field)
+     * @param null|array $context OPTIONAL Authentication data (identity and/or credential)
      * @return bool
      * @throws Exception\RuntimeException
      */

--- a/test/AuthenticationServiceTest.php
+++ b/test/AuthenticationServiceTest.php
@@ -35,7 +35,7 @@ class AuthenticationServiceTest extends \PHPUnit\Framework\TestCase
     public function testAdapter()
     {
         $this->assertNull($this->auth->getAdapter());
-        $successAdapter = new TestAsset\SuccessAdapter();
+        $successAdapter = new TestAsset\ValidatableAdapter();
         $ret = $this->auth->setAdapter($successAdapter);
         $this->assertSame($ret, $this->auth);
         $this->assertSame($successAdapter, $this->auth->getAdapter());
@@ -56,7 +56,7 @@ class AuthenticationServiceTest extends \PHPUnit\Framework\TestCase
 
     public function testAuthenticateSetAdapter()
     {
-        $result = $this->authenticate(new TestAsset\SuccessAdapter());
+        $result = $this->authenticate(new TestAsset\ValidatableAdapter());
         $this->assertInstanceOf('Zend\Authentication\Result', $result);
         $this->assertTrue($this->auth->hasIdentity());
         $this->assertEquals('someIdentity', $this->auth->getIdentity());
@@ -78,7 +78,7 @@ class AuthenticationServiceTest extends \PHPUnit\Framework\TestCase
     protected function authenticate($adapter = null)
     {
         if ($adapter === null) {
-            $adapter = new TestAsset\SuccessAdapter();
+            $adapter = new TestAsset\ValidatableAdapter();
         }
         return $this->auth->authenticate($adapter);
     }

--- a/test/AuthenticationServiceTest.php
+++ b/test/AuthenticationServiceTest.php
@@ -1,20 +1,16 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-authentication for the canonical source repository
+ * @copyright Copyright (c) 2005-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-authentication/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Authentication;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Authentication\AuthenticationService;
 
-/**
- * @group      Zend_Auth
- */
-class AuthenticationServiceTest extends \PHPUnit\Framework\TestCase
+class AuthenticationServiceTest extends TestCase
 {
     public function setUp()
     {

--- a/test/TestAsset/SuccessAdapter.php
+++ b/test/TestAsset/SuccessAdapter.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-authentication for the canonical source repository
+ * @copyright Copyright (c) 2012-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-authentication/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Authentication\TestAsset;

--- a/test/TestAsset/ValidatableAdapter.php
+++ b/test/TestAsset/ValidatableAdapter.php
@@ -9,13 +9,26 @@
 
 namespace ZendTest\Authentication\TestAsset;
 
-use Zend\Authentication\Adapter\AdapterInterface;
+use Zend\Authentication\Adapter\AbstractAdapter as AuthenticationAdapter;
 use Zend\Authentication\Result as AuthenticationResult;
 
-class SuccessAdapter implements AdapterInterface
+class ValidatableAdapter extends AuthenticationAdapter
 {
+    /**
+     * @var int Authentication result code
+     */
+    protected $code;
+
+    /**
+     * @param int $code
+     */
+    public function __construct($code = AuthenticationResult::SUCCESS)
+    {
+        $this->code = $code;
+    }
+
     public function authenticate()
     {
-        return new AuthenticationResult(AuthenticationResult::SUCCESS, 'someIdentity');
+        return new AuthenticationResult($this->code, 'someIdentity');
     }
 }

--- a/test/TestAsset/ValidatableAdapter.php
+++ b/test/TestAsset/ValidatableAdapter.php
@@ -1,10 +1,8 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
- * @license   http://framework.zend.com/license/new-bsd New BSD License
+ * @see       https://github.com/zendframework/zend-authentication for the canonical source repository
+ * @copyright Copyright (c) 2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @license   https://github.com/zendframework/zend-authentication/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Authentication\TestAsset;
@@ -17,7 +15,7 @@ class ValidatableAdapter extends AuthenticationAdapter
     /**
      * @var int Authentication result code
      */
-    protected $code;
+    private $code;
 
     /**
      * @param int $code
@@ -27,6 +25,9 @@ class ValidatableAdapter extends AuthenticationAdapter
         $this->code = $code;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function authenticate()
     {
         return new AuthenticationResult($this->code, 'someIdentity');


### PR DESCRIPTION
This patch incorporates feedback provided on #14; I was unable to push to the author's repository, so I am instead opening a new pull request.

The patch incorporates all changes in #14, plus some changes recommended and/or required on review.

What the patch accomplishes is the ability for a `Zend\Authentication\Validator\Authentication` to use the authentication adapter in the composed `AuthenticationService` instance when:

- no adapter is present in the validator
- the adapter in the authentication service is a `ValidatableAdapterInterface` instance

This simplifies usage, as the consumer of the validator no longer needs direct access to the authentication adapter.