### PR TITLE
Support user-defined error codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- Allow users to add error codes for authentication failure reasons
 
 ### Changed
 

--- a/src/Validator/Authentication.php
+++ b/src/Validator/Authentication.php
@@ -245,8 +245,8 @@ class Authentication extends AbstractValidator
         }
 
         $code = self::GENERAL;
-        if (array_key_exists($result->getCode(), self::CODE_MAP)) {
-            $code = self::CODE_MAP[$result->getCode()];
+        if (array_key_exists($result->getCode(), static::CODE_MAP)) {
+            $code = static::CODE_MAP[$result->getCode()];
         }
         $this->error($code);
 


### PR DESCRIPTION
**This allows the client code to supply his own domain-specific error codes. In my case these were expired account, disabled account, and password not set up.**

**It is also necessary for the client to supplement $this->messageTemplates and extend the Result class but this is already possible.**

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
  - [x] How will users use the new feature?
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [ ] Add tests for the new feature.  **=> is this applicable?**
  - [ ] Add documentation for the new feature.  **=> is this applicable?**
  - [x] Add a `CHANGELOG.md` entry for the new feature.

- [x] Is this related to quality assurance?
**Yes. Because my users are often confused by the generic error message when they can't log in** 

