### PR TITLE
Return 401 when token in basic is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Changed
 
-- Nothing.
+- [#42](https://github.com/zendframework/zend-authentication/pull/42) Changes authentication using Basic scheme
+  to re-challenge the client when credentials in Authorization header can not be base64 decoded.
 
 ### Deprecated
 

--- a/src/Adapter/Http.php
+++ b/src/Adapter/Http.php
@@ -484,7 +484,7 @@ class Http implements AdapterInterface
         $auth = substr($header, strlen('Basic '));
         $auth = base64_decode($auth);
         if (! $auth) {
-            throw new Exception\RuntimeException('Unable to base64_decode Authorization header value');
+            return $this->challengeClient();
         }
 
         // See ZF-1253. Validate the credentials the same way the digest

--- a/test/Adapter/Http/AuthTest.php
+++ b/test/Adapter/Http/AuthTest.php
@@ -215,6 +215,21 @@ class AuthTest extends TestCase
         $this->_checkUnauthorized($data, $basic);
     }
 
+    public function testBasicAuthTokenIsNotBase64()
+    {
+        // Attempt Basic Authentication with a valid username, but invalid
+        // password
+
+        // The expected Basic Www-Authenticate header value
+        $basic = [
+            'type'   => 'Basic ',
+            'realm'  => 'realm="' . $this->_basicConfig['realm'] . '"',
+        ];
+
+        $data = $this->_doAuth('Basic', 'basic');
+        $this->_checkUnauthorized($data, $basic);
+    }
+
     public function testDigestAuthValidCreds()
     {
         // Attempt Digest Authentication with a valid username and password


### PR DESCRIPTION
Missing token in Basic auth throw error instead of response with 401.