### PR TITLE
Pass with append string still valid

### DIFF
--- a/test/Adapter/Http/ApacheResolverTest.php
+++ b/test/Adapter/Http/ApacheResolverTest.php
@@ -159,7 +159,29 @@ class ApacheResolverTest extends TestCase
         $this->assertFalse($result->isValid());
     }
 
-        /**
+    public function testResolveNoValidPasswordWithoutPrependSign()
+    {
+        list($username, $password) = explode(':', base64_decode(base64_encode('admink:admin')));
+        $path = __DIR__ . '/TestAsset/htbasic-append.crypt';
+
+        $this->_apache->setFile($path);
+        $result = $this->_apache->resolve($username, null, $password);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
+        $this->assertTrue($result->isValid());
+    }
+
+    public function testResolveNoValidPasswordWithPrependSign()
+    {
+        list($username, $password) = explode(':', base64_decode(base64_encode('admink:admin').'X'));
+        $path = __DIR__ . '/TestAsset/htbasic-append.crypt';
+
+        $this->_apache->setFile($path);
+        $result = $this->_apache->resolve($username, null, $password);
+        $this->assertInstanceOf('Zend\Authentication\Result', $result);
+        $this->assertFalse($result->isValid());
+    }
+
+    /**
      * Ensure that resolve() failed for not valid password
      *
      * @dataProvider providePasswordFiles

--- a/test/Adapter/Http/TestAsset/htbasic-append.crypt
+++ b/test/Adapter/Http/TestAsset/htbasic-append.crypt
@@ -1,0 +1,1 @@
+admink:E6nt1mxRx7/6.


### PR DESCRIPTION
Adding string to correct basic token still allow to pass token when using crypt.