### PR TITLE
Remove insecure md5 example

### DIFF
--- a/docs/book/adapter/dbtable/callback-check.md
+++ b/docs/book/adapter/dbtable/callback-check.md
@@ -214,7 +214,7 @@ As an example, many websites require a user to activate their account before
 allowing them to login for the first time. We can add that criteria as follows:
 
 ```php
-// Create a basic adapter, with only an MD5() credential treatment:
+// Create a basic adapter
 $adapter = new AuthAdapter(
     $db,
     'users',

--- a/docs/book/adapter/dbtable/credential-treatment.md
+++ b/docs/book/adapter/dbtable/credential-treatment.md
@@ -15,17 +15,17 @@ More details are available in the next section.
 
 Passing passwords to database in plaintext for insert or verification is
 generally not recommended.  
-Sql statements can and usually are logged by the database, passwords in them
+Sql statements can and usually are logged by the database, and passwords in them
 become visible to anyone with access to the logs or monitoring tools that
 consume those logs.
 
-Safer way is to hash passwords and verify them against stored hash on the
-application side. This way password never needs to leave application and only
-hashed value exchanged with database.
+The safer approach is to hash passwords, and to verify them against a stored
+hash in your application code. This way the password never leaves the
+application, and only the hashed value is exchanged with the database.
 
-As such, this adapter is not recommended for new applications and existing
-applications should consider migrating to using PHP provided password handling
-functions `password_hash()` and `password_verify()`. See
+As such, this adapter is not recommended for new applications, and existing
+applications should consider migrating to using PHP-provided password handling
+functions such as `password_hash()` and `password_verify()`. See
 [CallbackCheckAdapter](callback-check.md) for more info.
 
 ## Configuration Options
@@ -261,8 +261,8 @@ $sqlAlter = "ALTER TABLE [users] "
 ```
 
 Salts should be created *for each user* using a cryptographically sound pseudo-random number generator (CSPRNG).
-PHP 7 provides an implementation via `random_bytes` (and 
-[`random_compat` for older supported versions of PHP](https://github.com/paragonie/random_compat)):
+PHP 7 provides an implementation via `random_bytes()` (and
+the [random_compat package provides them for older, supported versions of PHP](https://github.com/paragonie/random_compat)):
 
 ```php
 $salt = random_bytes(32);

--- a/docs/book/adapter/dbtable/credential-treatment.md
+++ b/docs/book/adapter/dbtable/credential-treatment.md
@@ -7,8 +7,26 @@ if an identity is returned, authentication succeeds. Credential
 treatments depends on your RDBMS, and while simple hashing function such as
 `md5` and `sha1` are generally available, it is recommended not to use them and
 rather use the RDBMS specific function such as
-[`PASSWORD(?)` for MySQL](http://dev.mysql.com/doc/refman/5.7/en/password-hashing.html).
+[`PASSWORD(?)` for MySQL](http://dev.mysql.com/doc/refman/5.7/en/password-hashing.html) or
+[`crypt()` for PostgreSQL](https://www.postgresql.org/docs/11/pgcrypto.html#id-1.11.7.34.6).
 More details are available in the next section.
+
+## Security considerations
+
+Passing passwords to database in plaintext for insert or verification is
+generally not recommended.  
+Sql statements can and usually are logged by the database, passwords in them
+become visible to anyone with access to the logs or monitoring tools that
+consume those logs.
+
+Safer way is to hash passwords and verify them against stored hash on the
+application side. This way password never needs to leave application and only
+hashed value exchanged with database.
+
+As such, this adapter is not recommended for new applications and existing
+applications should consider migrating to using PHP provided password handling
+functions `password_hash()` and `password_verify()`. See
+[CallbackCheckAdapter](callback-check.md) for more info.
 
 ## Configuration Options
 


### PR DESCRIPTION
Fixes #13 

- [x] Is this related to documentation?
Old documentation for `CredentialTreatmentAdapter` provides `md5()` in its usage example which might prompt users to utilize insecure practices. This PR removes `md5()` usage from the documentation and adds further guidance towards `CallbackCheckAdapter` and PHP functions `password_hash()` and `password_verify()` 
