### PR TITLE
Allow to configure validator with custom authentication result codes and validation messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file, in reverse 
 ### Added
 
 - [#44](https://github.com/zendframework/zend-authentication/pull/44) adds support for PHP 7.3.
+- [#47](https://github.com/zendframework/zend-authentication/pull/47) adds
+  configuration option to `Zend\Authentication\Validator\Authentication` for
+  mapping custom authentication result codes to existing and new validation
+  message types.
 
 ### Changed
 

--- a/docs/book/validator.md
+++ b/docs/book/validator.md
@@ -13,7 +13,7 @@ The available configuration options include:
 - `identity`: the identity or name of the identity field in the provided context.
 - `credential`: credential or the name of the credential field in the provided context.
 - `service`: an instance of `Zend\Authentication\AuthenticationService`.
-- `code_map`: map of authentication attempt result codes to validator message keys. 
+- `code_map`: map of `Zend\Authentication\Result` codes to validator message identifiers.
 
 ## Usage
 
@@ -35,14 +35,52 @@ $validator->isValid('myIdentity', [
 ]);
 ```
 
-## Configuring custom authentication result codes and messages
+## Validation messages
 
-Constructor configuration option `code_map` is a map of custom authentication result
-codes to validation messages keys.
+Authentication validator defines five failure message types. Identifiers
+for them are available as constants for convenience.
+Common authentication failure codes, defined as constants in
+`Zend\Authentication\Result`, are mapped to validation messages
+using map in `CODE_MAP` constant. Other authentication codes default to
+`general` message type.
 
-`code_map` can specify custom validation message key. New message template
-will be registered for that key, which can further be customized
-using `Validator::setMessage()` method or `messages` configuration option.
+```php
+namespace Zend\Authentication\Validator;
+
+use Zend\Authentication\Result;
+
+class Authentication
+{
+    const IDENTITY_NOT_FOUND = 'identityNotFound';
+    const IDENTITY_AMBIGUOUS = 'identityAmbiguous';
+    const CREDENTIAL_INVALID = 'credentialInvalid';
+    const UNCATEGORIZED      = 'uncategorized';
+    const GENERAL            = 'general';
+
+    const CODE_MAP = [
+        Result::FAILURE_IDENTITY_NOT_FOUND => self::IDENTITY_NOT_FOUND,
+        Result::FAILURE_CREDENTIAL_INVALID => self::CREDENTIAL_INVALID,
+        Result::FAILURE_IDENTITY_AMBIGUOUS => self::IDENTITY_AMBIGUOUS,
+        Result::FAILURE_UNCATEGORIZED      => self::UNCATEGORIZED,
+    ];
+}
+```
+
+Authentication validator extends `Zend\Validator\AbstractValidator` and provides
+common for all framework validators way to access, change or translate message templates.  
+More information is available in
+[zend-validator documentation](https://docs.zendframework.com/zend-validator/messages/)
+
+## Configure validation messages for custom authentication result codes
+
+The constructor configuration option `code_map` allows to map custom codes
+from `Zend\Authentication\Result` to validation message identifiers.  
+`code_map` is an array of integer code => string message identifier pairs
+
+A new custom message identifier can be specified in `code_map` which will then
+be registered as a new message type with template value set to `general` message.
+Once registered, message template for the new identifier can be changed
+as described in [zend-validator documentation](https://docs.zendframework.com/zend-validator/messages/)
 
 ```php
 use Zend\Authentication\Validator\Authentication as AuthenticationValidator;
@@ -52,13 +90,9 @@ $validator = new AuthenticationValidator([
         // map custom result code to existing message
         -990 => AuthenticationValidator::IDENTITY_NOT_FOUND,
         // map custom result code to a new message type
-        -991 => 'custom_error_message_key',
-    ],
-    'messages' => [
-        // provide message template for custom message type defined above
-        'custom_error_message_key' => 'Custom Error Happened'
+        -991 => 'custom_failure_identifier',
     ],
 ]);
 
-$validator->setMessage('Custom Error Happened', 'custom_error_message_key');
+$validator->setMessage('Custom Error Happened', 'custom_failure_identifier');
 ```

--- a/docs/book/validator.md
+++ b/docs/book/validator.md
@@ -37,11 +37,11 @@ $validator->isValid('myIdentity', [
 
 ## Validation messages
 
-Authentication validator defines five failure message types. Identifiers
+The authentication validator defines five failure message types; identifiers
 for them are available as constants for convenience.
 Common authentication failure codes, defined as constants in
 `Zend\Authentication\Result`, are mapped to validation messages
-using map in `CODE_MAP` constant. Other authentication codes default to
+using a map in `CODE_MAP` constant. Other authentication codes default to the
 `general` message type.
 
 ```php
@@ -66,21 +66,21 @@ class Authentication
 }
 ```
 
-Authentication validator extends `Zend\Validator\AbstractValidator` and provides
-common for all framework validators way to access, change or translate message templates.  
-More information is available in
+The authentication validator extends `Zend\Validator\AbstractValidator`, providing
+a way common for all framework validators to access, change or translate message templates.  
+More information is available in the
 [zend-validator documentation](https://docs.zendframework.com/zend-validator/messages/)
 
 ## Configure validation messages for custom authentication result codes
 
-The constructor configuration option `code_map` allows to map custom codes
+The constructor configuration option `code_map` allows mapping custom codes
 from `Zend\Authentication\Result` to validation message identifiers.  
 `code_map` is an array of integer code => string message identifier pairs
 
 A new custom message identifier can be specified in `code_map` which will then
-be registered as a new message type with template value set to `general` message.
-Once registered, message template for the new identifier can be changed
-as described in [zend-validator documentation](https://docs.zendframework.com/zend-validator/messages/)
+be registered as a new message type with the template value set to the `general` message.
+Once registered, the message template for the new identifier can be changed
+as described in the [zend-validator documentation](https://docs.zendframework.com/zend-validator/messages/).
 
 ```php
 use Zend\Authentication\Validator\Authentication as AuthenticationValidator;

--- a/docs/book/validator.md
+++ b/docs/book/validator.md
@@ -13,6 +13,7 @@ The available configuration options include:
 - `identity`: the identity or name of the identity field in the provided context.
 - `credential`: credential or the name of the credential field in the provided context.
 - `service`: an instance of `Zend\Authentication\AuthenticationService`.
+- `code_map`: map of authentication attempt result codes to validator message keys. 
 
 ## Usage
 
@@ -32,4 +33,32 @@ $validator->setCredential('myCredentialContext');
 $validator->isValid('myIdentity', [
      'myCredentialContext' => 'myCredential',
 ]);
+```
+
+## Configuring custom authentication result codes and messages
+
+Constructor configuration option `code_map` is a map of custom authentication result
+codes to validation messages keys.
+
+`code_map` can specify custom validation message key. New message template
+will be registered for that key, which can further be customized
+using `Validator::setMessage()` method or `messages` configuration option.
+
+```php
+use Zend\Authentication\Validator\Authentication as AuthenticationValidator;
+
+$validator = new AuthenticationValidator([
+    'code_map' => [
+        // map custom result code to existing message
+        -990 => AuthenticationValidator::IDENTITY_NOT_FOUND,
+        // map custom result code to a new message type
+        -991 => 'custom_error_message_key',
+    ],
+    'messages' => [
+        // provide message template for custom message type defined above
+        'custom_error_message_key' => 'Custom Error Happened'
+    ],
+]);
+
+$validator->setMessage('Custom Error Happened', 'custom_error_message_key');
 ```

--- a/test/Validator/AuthenticationTest.php
+++ b/test/Validator/AuthenticationTest.php
@@ -160,6 +160,17 @@ class AuthenticationTest extends TestCase
         $this->assertEquals('Custom Error', $templates['custom_error']);
     }
 
+    public function testCodeMapOptionRequiresMessageKeyToBeString()
+    {
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Message key in code_map option must be a non-empty string');
+        $auth = new AuthenticationValidator([
+            'code_map' => [
+                -999 => [],
+            ]
+        ]);
+    }
+
     public function testSetters()
     {
         $this->validator->setAdapter($this->authAdapter);

--- a/test/Validator/AuthenticationTest.php
+++ b/test/Validator/AuthenticationTest.php
@@ -1,14 +1,13 @@
 <?php
 /**
  * @see       https://github.com/zendframework/zend-authentication for the canonical source repository
- * @copyright Copyright (c) 2013-2018 Zend Technologies USA Inc. (https://www.zend.com)
+ * @copyright Copyright (c) 2013-2019 Zend Technologies USA Inc. (https://www.zend.com)
  * @license   https://github.com/zendframework/zend-authentication/blob/master/LICENSE.md New BSD License
  */
 
 namespace ZendTest\Authentication\Validator;
 
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 use Zend\Authentication\Adapter\ValidatableAdapterInterface;
 use Zend\Authentication\AuthenticationService;
 use Zend\Authentication\Exception;
@@ -52,6 +51,113 @@ class AuthenticationTest extends TestCase
         $this->assertSame($auth->getService(), $this->authService);
         $this->assertSame($auth->getIdentity(), 'username');
         $this->assertSame($auth->getCredential(), 'password');
+    }
+
+    public function testConstructorOptionCodeMapOverridesDefaultMap()
+    {
+        $authAdapter = new AuthTest\TestAsset\ValidatableAdapter(AuthenticationResult::FAILURE_UNCATEGORIZED);
+        $auth = new AuthenticationValidator([
+            'adapter' => $authAdapter,
+            'service' => $this->authService,
+            'identity' => 'username',
+            'credential' => 'password',
+            'code_map' => [
+                AuthenticationResult::FAILURE_UNCATEGORIZED => AuthenticationValidator::IDENTITY_NOT_FOUND,
+            ]
+        ]);
+        $this->assertFalse($auth->isValid());
+        $this->assertArrayHasKey(
+            AuthenticationValidator::IDENTITY_NOT_FOUND,
+            $auth->getMessages(),
+            print_r($auth->getMessages(), true)
+        );
+    }
+
+    public function testConstructorOptionCodeMapUsesDefaultMapForOmittedCodes()
+    {
+        $authAdapter = new AuthTest\TestAsset\ValidatableAdapter(AuthenticationResult::FAILURE_IDENTITY_AMBIGUOUS);
+        $auth = new AuthenticationValidator([
+            'adapter' => $authAdapter,
+            'service' => $this->authService,
+            'identity' => 'username',
+            'credential' => 'password',
+            'code_map' => [
+                AuthenticationResult::FAILURE_UNCATEGORIZED => AuthenticationValidator::IDENTITY_NOT_FOUND,
+            ]
+        ]);
+        $this->assertFalse($auth->isValid());
+        $this->assertArrayHasKey(
+            AuthenticationValidator::IDENTITY_AMBIGUOUS,
+            $auth->getMessages(),
+            print_r($auth->getMessages(), true)
+        );
+    }
+
+    public function testCodeMapAllowsToSpecifyCustomCodes()
+    {
+        $authAdapter = new AuthTest\TestAsset\ValidatableAdapter(-999);
+        $auth = new AuthenticationValidator([
+            'adapter' => $authAdapter,
+            'service' => $this->authService,
+            'identity' => 'username',
+            'credential' => 'password',
+            'code_map' => [
+                -999 => AuthenticationValidator::IDENTITY_NOT_FOUND,
+            ]
+        ]);
+        $this->assertFalse($auth->isValid());
+        $this->assertArrayHasKey(
+            AuthenticationValidator::IDENTITY_NOT_FOUND,
+            $auth->getMessages(),
+            print_r($auth->getMessages(), true)
+        );
+    }
+
+    public function testCodeMapAllowsToAddCustomMessageTemplates()
+    {
+        $auth = new AuthenticationValidator([
+            'code_map' => [
+                -999 => 'custom_error',
+            ]
+        ]);
+        $templates = $auth->getMessageTemplates();
+        $this->assertArrayHasKey(
+            'custom_error',
+            $templates,
+            print_r($templates, true)
+        );
+    }
+
+    /**
+     * @depends testCodeMapAllowsToAddCustomMessageTemplates
+     */
+    public function testCodeMapCustomMessageTemplateValueDefaultsToGeneralMessageTemplate()
+    {
+        $auth = new AuthenticationValidator([
+            'code_map' => [
+                -999 => 'custom_error',
+            ]
+        ]);
+        $templates = $auth->getMessageTemplates();
+        $this->assertEquals($templates['general'], $templates['custom_error']);
+    }
+
+    /**
+     * @depends testCodeMapAllowsToAddCustomMessageTemplates
+     */
+    public function testCustomMessageTemplateValueCanBeProvidedAsOption()
+    {
+        $auth = new AuthenticationValidator([
+            'code_map' => [
+                -999 => 'custom_error',
+            ],
+            'messages' => [
+                'custom_error' => 'Custom Error'
+            ]
+
+        ]);
+        $templates = $auth->getMessageTemplates();
+        $this->assertEquals('Custom Error', $templates['custom_error']);
     }
 
     public function testSetters()


### PR DESCRIPTION
This PR adds feature to configure Authentication validator with user defined authentication result codes and their corresponding validation messages.
Solves #41 

- [x] Are you creating a new feature?
  - [x] Why is the new feature needed? What purpose does it serve?
    Authentication Result allows custom result codes to be specified but Authentication validator does not provide a way to map those codes to meaningful validation error messages. This feature fixes that by introducing new configuration option for Authentication validator. 
  - [x] How will users use the new feature?
    New constructor configuration option `code_map` added. It is an array of `[int $resultCode => string $validatorMessageKey]`.
    Custom validator message key can be specified which is then registered as a new template that can be modified using common ways provided by `Zend\Validator\AbstractValidator`: `setMessage()` method or `messages` option.
  - [x] Base your feature on the `develop` branch, and submit against that branch.
  - [x] Add only one feature per pull request; split multiple features over multiple pull requests
  - [x] Add tests for the new feature.
  - [x] Add documentation for the new feature.
  - [x] Add a `CHANGELOG.md` entry for the new feature.
